### PR TITLE
Fix CountryDetail list structure and keys

### DIFF
--- a/frontend/src/CountryDetail.jsx
+++ b/frontend/src/CountryDetail.jsx
@@ -1,12 +1,11 @@
-import './App.css'
-import React, { useEffect, useState }　from "react";
+import './App.css';
+import React, { useEffect, useState } from "react";
 import { Link, useParams } from 'react-router-dom';
 
 function CountryDetail(){
-    const[cities, setCities] = useState([]);
-    const baseUrl = process.env.REACT_APP_API_BASE_URL
-    const { id } = useParams();
-    const { code } = useParams();
+    const [cities, setCities] = useState([]);
+    const baseUrl = process.env.REACT_APP_API_BASE_URL;
+    const { id, code } = useParams();
 
     useEffect(()=>{
         console.log("アクセス先:", `${baseUrl}/continents/${id}/${code}`);
@@ -20,23 +19,23 @@ function CountryDetail(){
         .catch(err => console.log("データ取得失敗:",err));
     },[baseUrl, id, code]);
 
-
     return(
-        <ul>
-            <div className="card-container">
-                <h2>{code}</h2>
-                <Link to="/">←← 大陸一覧に戻る</Link>
-                <Link to={`/continents/${id}`}>← 国一覧に戻る</Link>
-                {cities.map((city,　i) => (
-                    <li key = {i}>
+        <div className="card-container">
+            <h2>{code}</h2>
+            <Link to="/">←← 大陸一覧に戻る</Link>
+            <Link to={`/continents/${id}`}>← 国一覧に戻る</Link>
+            <ul>
+                {cities.map((city) => (
+                    <li key={city.都市名}>
                         <div className="city-card">
                             <h3>{city.都市名}</h3>
                             <p>(都市人口:{city.都市人口.toLocaleString()})</p>
                         </div>
                     </li>
                 ))}
-            </div>
-        </ul>
-    )
+            </ul>
+        </div>
+    );
 }
+
 export default CountryDetail;


### PR DESCRIPTION
## Summary
- refactor CountryDetail component to keep proper list markup
- use city names as React keys and simplify parameter retrieval

## Testing
- `npm test` (fails: Missing script "test")
- `CI=true npm --prefix frontend test` (fails: Cannot find module 'react-router-dom' from 'src/App.jsx')

------
https://chatgpt.com/codex/tasks/task_e_68a58d6f2d6083309ea63861f5451f1b